### PR TITLE
Added support for gvim and a --editor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Values, though, may include this character.
 ### directly on commandline
 Configuration is done via commandline options:
 
-    usage: xattrvi [-h] [-v] [-e STDENC] [-s] [--hide-undecodable] filename
+    usage: xattrvi [-h] [-v] [-e STDENC] [-s] [--editor EDITOR] [--hide-undecodable] filename
     
     xattrvi - modify xattributes of files the simple way
     
@@ -45,6 +45,8 @@ Configuration is done via commandline options:
       -e STDENC, --encoding STDENC
                             encoding to be used for value-decoding, defaults to utf-8
       --hide-undecodable    hide entries whose value could not be decoded properly
+      --editor              specify custom editor on the command line.
+                            Example: --editor 'gvim --nofork'.
 
 ### xattrvirc
 

--- a/xattrvi
+++ b/xattrvi
@@ -118,9 +118,8 @@ with open(tmpfile.name, 'w') as f:
 		f.write("# attributes in other namespaces:\n\n")
 		f.write("\n#".join([ "{0:10}   : {1}".format(key, value) for key, value in otherxattrs]))
 
-# code for editor quirks
 args.editor = shlex.split(args.editor)
-retval = subprocess.call(args.editor+ [tmpfile.name])
+retval = subprocess.call(args.editor + [tmpfile.name])
 
 if retval != 0:
 	print("!! Your editor {0} exited nonzero with {1}, removing stale tmpfile and aborting".format(args.editor, retval), file=sys.stderr)

--- a/xattrvi
+++ b/xattrvi
@@ -7,7 +7,7 @@ parser = argparse.ArgumentParser(description='xattrvi - modify xattributes of fi
 parser.add_argument('-e', '--encoding', action='store', dest='stdenc', type=str, default='utf-8', help='encoding to be used for value-decoding, defaults to utf-8')
 parser.add_argument('--hide-undecodable', action='store_true', default=False, dest='show_undecodable', help='hide entries whose value could not be decoded properly')
 parser.add_argument('filename', action='store', type=str, default=None, help='file that needs to get modified')
-parser.add_argument('--editor', action='store', type=str, dest='editor', help='use this particular editor')
+parser.add_argument('--editor', action='store', type=str, dest='editor', default=os.environ.get('EDITOR') or 'nano', help='use this particular editor')
 
 args = parser.parse_args(sys.argv[1:])
 
@@ -118,16 +118,15 @@ with open(tmpfile.name, 'w') as f:
 		f.write("# attributes in other namespaces:\n\n")
 		f.write("\n#".join([ "{0:10}   : {1}".format(key, value) for key, value in otherxattrs]))
 
-
-# let the user change those attributes
+# code for editor quirks
 if re.findall('gvim',args.editor):
-    # needs special nofork for subprocess to wait for gvim to return
-    retval = subprocess.call(['gvim','--nofork', tmpfile.name])
+    # needs special nofork for subprocess to wait for gvim to return. simply adds the nofork to argument. gvim allows for repeated arguments.
+    retval = subprocess.call([args.editor,'--nofork', tmpfile.name])
 else:
-    retval = subprocess.call([args.editor or os.environ.get('EDITOR') or 'nano', tmpfile.name])
+    retval = subprocess.call([args.editor, tmpfile.name])
 
 if retval != 0:
-	print("!! Your editor {0} exited nonzero with {1}, removing stale tmpfile and aborting".format(args.editor or os.environ['EDITOR'], retval), file=sys.stderr)
+	print("!! Your editor {0} exited nonzero with {1}, removing stale tmpfile and aborting".format(args.editor, retval), file=sys.stderr)
 	sys.exit(1)
 
 

--- a/xattrvi
+++ b/xattrvi
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys, os, subprocess, tempfile, argparse, codecs, re
+import sys, os, subprocess, tempfile, argparse, codecs, shlex
 
 parser = argparse.ArgumentParser(description='xattrvi - modify xattributes of files the simple way')
 
@@ -119,11 +119,8 @@ with open(tmpfile.name, 'w') as f:
 		f.write("\n#".join([ "{0:10}   : {1}".format(key, value) for key, value in otherxattrs]))
 
 # code for editor quirks
-if re.findall('gvim',args.editor):
-    # needs special nofork for subprocess to wait for gvim to return. simply adds the nofork to argument. gvim allows for repeated arguments.
-    retval = subprocess.call([args.editor,'--nofork', tmpfile.name])
-else:
-    retval = subprocess.call([args.editor, tmpfile.name])
+args.editor = shlex.split(args.editor)
+retval = subprocess.call(args.editor+ [tmpfile.name])
 
 if retval != 0:
 	print("!! Your editor {0} exited nonzero with {1}, removing stale tmpfile and aborting".format(args.editor, retval), file=sys.stderr)

--- a/xattrvi
+++ b/xattrvi
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys, os, subprocess, tempfile, argparse, codecs
+import sys, os, subprocess, tempfile, argparse, codecs, re
 
 parser = argparse.ArgumentParser(description='xattrvi - modify xattributes of files the simple way')
 
@@ -120,7 +120,12 @@ with open(tmpfile.name, 'w') as f:
 
 
 # let the user change those attributes
-retval = subprocess.call([args.editor or os.environ.get('EDITOR') or 'nano', tmpfile.name])
+if re.findall('gvim',args.editor):
+    # needs special nofork for subprocess to wait for gvim to return
+    retval = subprocess.call(['gvim','--nofork', tmpfile.name])
+else:
+    retval = subprocess.call([args.editor or os.environ.get('EDITOR') or 'nano', tmpfile.name])
+
 if retval != 0:
 	print("!! Your editor {0} exited nonzero with {1}, removing stale tmpfile and aborting".format(args.editor or os.environ['EDITOR'], retval), file=sys.stderr)
 	sys.exit(1)

--- a/xattrvi
+++ b/xattrvi
@@ -7,6 +7,7 @@ parser = argparse.ArgumentParser(description='xattrvi - modify xattributes of fi
 parser.add_argument('-e', '--encoding', action='store', dest='stdenc', type=str, default='utf-8', help='encoding to be used for value-decoding, defaults to utf-8')
 parser.add_argument('--hide-undecodable', action='store_true', default=False, dest='show_undecodable', help='hide entries whose value could not be decoded properly')
 parser.add_argument('filename', action='store', type=str, default=None, help='file that needs to get modified')
+parser.add_argument('--editor', action='store', type=str, dest='editor', help='use this particular editor')
 
 args = parser.parse_args(sys.argv[1:])
 
@@ -119,9 +120,9 @@ with open(tmpfile.name, 'w') as f:
 
 
 # let the user change those attributes
-retval = subprocess.call([os.environ.get('EDITOR') or 'nano', tmpfile.name])
+retval = subprocess.call([args.editor or os.environ.get('EDITOR') or 'nano', tmpfile.name])
 if retval != 0:
-	print("!! Your editor {0} exited nonzero with {1}, removing stale tmpfile and aborting".format(os.environ['EDITOR'], retval), file=sys.stderr)
+	print("!! Your editor {0} exited nonzero with {1}, removing stale tmpfile and aborting".format(args.editor or os.environ['EDITOR'], retval), file=sys.stderr)
 	sys.exit(1)
 
 

--- a/xattrvi-gvim.desktop
+++ b/xattrvi-gvim.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=xattrvi-gvim
+Exec=xattrvi --editor 'gvim --nofork' %u
+Terminal=false
+Type=Application
+StartupNotify=true
+MimeType=inode/directory;application/octet-stream;text/plain;application/pdf;

--- a/xattrvi.desktop
+++ b/xattrvi.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=xattrvi
+Exec=/opt/bin/xattrvi/xattrvi --editor vim %u
+Terminal=true
+Type=Application
+StartupNotify=true
+MimeType=inode/directory;application/octet-stream;text/plain;application/pdf;

--- a/xattrvi.desktop
+++ b/xattrvi.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Name=xattrvi
-#Exec=/opt/bin/xattrvi/xattrvi --hide-undecodable --editor 'vim -c "set shell=/bin/bash"' %u
-Exec=/opt/bin/xattrvi/xattrvi --editor 'gvim --nofork' %u
-Terminal=false
+Exec=xattrvi --hide-undecodable --editor 'vim -c "set shell=/bin/bash"' %u
+# the desktop file needs Terminal=true for an editor that works in a shell
+Terminal=true
 Type=Application
 StartupNotify=true
 MimeType=inode/directory;application/octet-stream;text/plain;application/pdf;
+

--- a/xattrvi.desktop
+++ b/xattrvi.desktop
@@ -1,7 +1,8 @@
 [Desktop Entry]
 Name=xattrvi
-Exec=/opt/bin/xattrvi/xattrvi --editor vim %u
-Terminal=true
+#Exec=/opt/bin/xattrvi/xattrvi --hide-undecodable --editor 'vim -c "set shell=/bin/bash"' %u
+Exec=/opt/bin/xattrvi/xattrvi --editor 'gvim --nofork' %u
+Terminal=false
 Type=Application
 StartupNotify=true
 MimeType=inode/directory;application/octet-stream;text/plain;application/pdf;


### PR DESCRIPTION
This allows one to use the program from within a gui filemanager like gvim.
Also added a xattrvi.desktop file that has to be added to ~/.local/share/applications/ if necessary. 
Will have to update README.md.